### PR TITLE
Using cookies and token-based auth mechanisms

### DIFF
--- a/src/main/java/org/cristalise/restapi/AgentJobList.java
+++ b/src/main/java/org/cristalise/restapi/AgentJobList.java
@@ -24,7 +24,7 @@ public class AgentJobList extends RemoteMapAccess {
 			@DefaultValue("0") @QueryParam("start") Integer start, 
 			@QueryParam("batch") Integer batchSize, @CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = getProxy(uuid);
 
 		if (!(item instanceof AgentProxy))
@@ -58,7 +58,7 @@ public class AgentJobList extends RemoteMapAccess {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response getEvent(@PathParam("uuid") String uuid, @PathParam("jobId") String jobId, @CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = getProxy(uuid);
 		if (!(item instanceof AgentProxy))
 			throw ItemUtils.createWebAppException("UUID does not belong to an Agent", Response.Status.BAD_REQUEST);
@@ -77,7 +77,7 @@ public class AgentJobList extends RemoteMapAccess {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response getRoles(@PathParam("uuid") String uuid, @CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = getProxy(uuid);
 		if (!(item instanceof AgentProxy))
 			throw ItemUtils.createWebAppException("UUID does not belong to an Agent", Response.Status.BAD_REQUEST);

--- a/src/main/java/org/cristalise/restapi/CookieLogin.java
+++ b/src/main/java/org/cristalise/restapi/CookieLogin.java
@@ -41,9 +41,9 @@ public class CookieLogin extends RestHandler {
 			
 			int cookieLife = Gateway.getProperties().getInt("REST.loginCookieLife", 0);
 			if (cookieLife > 0) 
-				cookie = new NewCookie(COOKIENAME, makeCookie(agentData), "/", null, null, cookieLife, false);
+				cookie = new NewCookie(COOKIENAME, encryptAuthData(agentData), "/", null, null, cookieLife, false);
         	else
-        		cookie = new NewCookie(COOKIENAME, makeCookie(agentData));
+        		cookie = new NewCookie(COOKIENAME, encryptAuthData(agentData));
 			return Response.ok().cookie(cookie).build();
 		} catch (Exception e) {
 			Logger.error(e);

--- a/src/main/java/org/cristalise/restapi/ItemCollection.java
+++ b/src/main/java/org/cristalise/restapi/ItemCollection.java
@@ -14,7 +14,7 @@ public class ItemCollection extends ItemUtils {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response getCollections(@PathParam("uuid") String uuid, @CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = getProxy(uuid);
 		return toJSON(enumerate(item, ClusterStorage.COLLECTION, "collection", uri));
 	}
@@ -25,7 +25,7 @@ public class ItemCollection extends ItemUtils {
 	public Response getLastCollection(@PathParam("uuid") String uuid, @PathParam("name") String collName, 
 			@CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = getProxy(uuid);
 		try {
 			return toJSON(makeCollectionData(item.getCollection(collName), uri));
@@ -39,7 +39,7 @@ public class ItemCollection extends ItemUtils {
 	public Response getCollectionVersions(@PathParam("uuid") String uuid, @PathParam("name") String collName, 
 			@CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = getProxy(uuid);
 		return toJSON(enumerate(item, ClusterStorage.COLLECTION+"/"+collName, "collection/"+collName+"/version", uri));
 	}
@@ -49,7 +49,7 @@ public class ItemCollection extends ItemUtils {
 	public Response getCollectionVersion(@PathParam("uuid") String uuid, @PathParam("name") String collName, 
 			@PathParam("version") String collVersion, @CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = getProxy(uuid);
 		try {
 			return toJSON(makeCollectionData(item.getCollection(collName, collVersion.equals("last")?null:Integer.valueOf(collVersion)), uri));

--- a/src/main/java/org/cristalise/restapi/ItemData.java
+++ b/src/main/java/org/cristalise/restapi/ItemData.java
@@ -23,7 +23,7 @@ public class ItemData extends ItemUtils {
 	public Response getSchemas(@PathParam("uuid") String uuid,
 			@CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = ItemRoot.getProxy(uuid);
 		return toJSON(enumerate(item, ClusterStorage.VIEWPOINT, "data", uri));
 	}
@@ -35,7 +35,7 @@ public class ItemData extends ItemUtils {
 			@PathParam("schema") String schema,
 			@CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = ItemRoot.getProxy(uuid);
 		return toJSON(enumerate(item, ClusterStorage.VIEWPOINT+"/"+schema, "data/"+schema, uri));
 	}
@@ -51,7 +51,7 @@ public class ItemData extends ItemUtils {
      * @return
      */
 	private Response queryData(String uuid, String schema, String viewName, Cookie authCookie, UriInfo uri, boolean json) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = ItemRoot.getProxy(uuid);
 		Viewpoint view;
 		try {
@@ -110,7 +110,7 @@ public class ItemData extends ItemUtils {
 			@PathParam("viewName") String viewName,
 			@CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = ItemRoot.getProxy(uuid);
 		Viewpoint view;
 		try {
@@ -138,7 +138,7 @@ public class ItemData extends ItemUtils {
 			@PathParam("viewName") String viewName,
 			@CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = ItemRoot.getProxy(uuid);
 		History history;
 		try {
@@ -170,7 +170,7 @@ public class ItemData extends ItemUtils {
 			@PathParam("event") Integer eventId,
 			@CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = ItemRoot.getProxy(uuid);
 		Event ev;
 		try {
@@ -200,7 +200,7 @@ public class ItemData extends ItemUtils {
 			@PathParam("event") Integer eventId,
 			@CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = ItemRoot.getProxy(uuid);
 		Event ev;
 		try {

--- a/src/main/java/org/cristalise/restapi/ItemHistory.java
+++ b/src/main/java/org/cristalise/restapi/ItemHistory.java
@@ -20,7 +20,7 @@ public class ItemHistory extends RemoteMapAccess {
 	public Response list(@PathParam("uuid") String uuid, @QueryParam("start") Integer start, 
 			@QueryParam("batch") Integer batchSize,	@CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = getProxy(uuid);
 		if (start == null) start = 0;
 		if (batchSize == null) batchSize = Gateway.getProperties().getInt("REST.Event.DefaultBatchSize", 
@@ -45,7 +45,7 @@ public class ItemHistory extends RemoteMapAccess {
 	public Response getEvent(@PathParam("uuid") String uuid, @PathParam("eventId") String eventId, 
 			@CookieParam(COOKIENAME) Cookie authCookie,	@Context UriInfo uri)
 	{
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = getProxy(uuid);
 		Event ev = (Event)get(item, ClusterStorage.HISTORY, eventId);
 		return toJSON(makeEventData(ev, uri));
@@ -61,7 +61,7 @@ public class ItemHistory extends RemoteMapAccess {
      * @return
      */
 	private Response getEventOutcome(String uuid, String eventId, Cookie authCookie, UriInfo uri, boolean json) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = getProxy(uuid);
 		Event ev = (Event)get(item, ClusterStorage.HISTORY, eventId);
 		if (ev.getSchemaName() == null || ev.getSchemaName().equals(""))

--- a/src/main/java/org/cristalise/restapi/ItemProperty.java
+++ b/src/main/java/org/cristalise/restapi/ItemProperty.java
@@ -16,7 +16,7 @@ public class ItemProperty extends ItemUtils {
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response listProperties(@PathParam("uuid") String uuid, @CookieParam(COOKIENAME) Cookie authCookie) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		try {
 			return toJSON(getPropertySummary(getProxy(uuid)));
 		} catch (ObjectNotFoundException e) {
@@ -29,7 +29,7 @@ public class ItemProperty extends ItemUtils {
 	@Produces(MediaType.TEXT_PLAIN)
 	public String getProperty(@PathParam("uuid") String uuid, @PathParam("name") String name, 
 			@CookieParam(COOKIENAME) Cookie authCookie) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		try {
 			return getProxy(uuid).getProperty(name);
 		} catch (ObjectNotFoundException e) {
@@ -42,7 +42,7 @@ public class ItemProperty extends ItemUtils {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response getPropertyDetails(@PathParam("uuid") String uuid, @PathParam("name") String name, 
 			@CookieParam(COOKIENAME) Cookie authCookie) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		LinkedHashMap<String, Object> propDetails = new LinkedHashMap<String, Object>();
 		try {
 			Property prop = (Property)getProxy(uuid).getObject(ClusterStorage.PROPERTY+"/"+name);

--- a/src/main/java/org/cristalise/restapi/ItemRoot.java
+++ b/src/main/java/org/cristalise/restapi/ItemRoot.java
@@ -21,7 +21,7 @@ public class ItemRoot extends ItemUtils {
 	@Path("name")
 	@Produces(MediaType.TEXT_PLAIN)
 	public String getName(@PathParam("uuid") String uuid, @CookieParam(COOKIENAME) Cookie authCookie) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		return getProxy(uuid).getName();
 	}
 
@@ -29,7 +29,7 @@ public class ItemRoot extends ItemUtils {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response getItemSummary(@PathParam("uuid") String uuid, @CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		ItemProxy item = getProxy(uuid);
 		
 		LinkedHashMap<String, Object> itemSummary = new LinkedHashMap<String, Object>();

--- a/src/main/java/org/cristalise/restapi/PathAccess.java
+++ b/src/main/java/org/cristalise/restapi/PathAccess.java
@@ -39,7 +39,7 @@ public class PathAccess extends RestHandler {
 			@CookieParam(COOKIENAME) 				Cookie authCookie,
 			@Context 								UriInfo uri)
 	{
-		checkAuth(authCookie);	
+		checkAuthCookie(authCookie);	
 		DomainPath domPath = new DomainPath(path);
 		if (batchSize == null) batchSize = Gateway.getProperties().getInt("REST.Path.DefaultBatchSize", 
 				Gateway.getProperties().getInt("REST.DefaultBatchSize", 75));

--- a/src/main/java/org/cristalise/restapi/RoleAccess.java
+++ b/src/main/java/org/cristalise/restapi/RoleAccess.java
@@ -17,7 +17,7 @@ public class RoleAccess extends RestHandler {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response listRoles(@CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		LinkedHashMap<String, Object> roles = new LinkedHashMap<>();
 		Iterator<org.cristalise.kernel.lookup.Path> iter = Gateway.getLookup().search(new RolePath(), "*");
 		while (iter.hasNext()) {
@@ -32,7 +32,7 @@ public class RoleAccess extends RestHandler {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response getRole(@PathParam("role") String roleName, @CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		RolePath role;
 		try {
 			role = Gateway.getLookup().getRolePath(roleName);

--- a/src/main/java/org/cristalise/restapi/SchemaAccess.java
+++ b/src/main/java/org/cristalise/restapi/SchemaAccess.java
@@ -10,7 +10,7 @@ public class SchemaAccess extends ResourceAccess {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response listAllSchemas(@CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		return listAllResources("OutcomeDesc", uri);
 	}
 	
@@ -19,7 +19,7 @@ public class SchemaAccess extends ResourceAccess {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response listSchemaVersions(@PathParam("name") String name, @CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		return listResourceVersions("OutcomeDesc", "Schema", "schema", name, uri);
 	}
 	
@@ -28,7 +28,7 @@ public class SchemaAccess extends ResourceAccess {
 	@Produces(MediaType.TEXT_XML)
 	public Response getSchema(@PathParam("name") String name, @PathParam("version") Integer version, 
 			@CookieParam(COOKIENAME) Cookie authCookie) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		return getResource("OutcomeDesc", "Schema", name, version);
 	}
 }

--- a/src/main/java/org/cristalise/restapi/StateMachineAccess.java
+++ b/src/main/java/org/cristalise/restapi/StateMachineAccess.java
@@ -10,7 +10,7 @@ public class StateMachineAccess extends ResourceAccess {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response listAllStateMachines(@CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		return listAllResources("StateMachine", uri);
 	}
 	
@@ -19,7 +19,7 @@ public class StateMachineAccess extends ResourceAccess {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response listStateMachineVersions(@PathParam("name") String name, @CookieParam(COOKIENAME) Cookie authCookie,
 			@Context UriInfo uri) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		return listResourceVersions("StateMachine", "StateMachine", "stateMachine", name, uri);
 	}
 	
@@ -28,7 +28,7 @@ public class StateMachineAccess extends ResourceAccess {
 	@Produces(MediaType.TEXT_XML)
 	public Response getStateMachineData(@PathParam("name") String name, @PathParam("version") Integer version,
 			@CookieParam(COOKIENAME) Cookie authCookie) {
-		checkAuth(authCookie);
+		checkAuthCookie(authCookie);
 		return getResource("StateMachine", "StateMachine", name, version);
 	}
 }

--- a/src/main/java/org/cristalise/restapi/TokenLogin.java
+++ b/src/main/java/org/cristalise/restapi/TokenLogin.java
@@ -1,0 +1,58 @@
+package org.cristalise.restapi;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.cristalise.kernel.common.InvalidDataException;
+import org.cristalise.kernel.common.ObjectNotFoundException;
+import org.cristalise.kernel.lookup.AgentPath;
+import org.cristalise.kernel.process.Gateway;
+import org.cristalise.kernel.utils.Logger;
+
+@Path("auth")
+public class TokenLogin extends RestHandler {
+
+	@GET
+	@Produces(MediaType.TEXT_PLAIN)
+	public Response login(@QueryParam("user") final String user,
+			@QueryParam("pass") final String pass, @Context final UriInfo uri) {
+		try {
+			if (!Gateway.getAuthenticator().authenticate(user, pass, null)) {
+				throw new WebApplicationException("Bad username/password", 401);
+			}
+		} catch (InvalidDataException e) {
+			Logger.error(e);
+			throw new WebApplicationException("Problem logging in");
+		} catch (ObjectNotFoundException e1) {
+			throw new WebApplicationException("Bad username/password", 401);
+		}
+
+		AgentPath agentPath;
+		try {
+			agentPath = Gateway.getLookup().getAgentPath(user);
+		} catch (ObjectNotFoundException e) {
+			Logger.error(e);
+			throw new WebApplicationException("Agent '" + user + "' not found",
+					404);
+		}
+
+		// create and set token
+		AuthData agentData = new AuthData(agentPath);
+		try {
+
+			String token = encryptAuthData(agentData);
+			return Response.ok(token).build();
+		} catch (Exception e) {
+			Logger.error(e);
+			throw new WebApplicationException("Error creating token");
+		}
+	}
+
+}


### PR DESCRIPTION
- Please consider this pull-request as an example to support more generic authentication mechanism.
- We need additionally to add adequate Cristal initialisation properties (not cookies only based).
- The "/login" path should be revisited as we can have more than authentication method. E.g; "/login/cookie" "/login/token", or using query parameters "/login?method=cookie" "login?method=token".